### PR TITLE
Add lambda for arity-checked functions.

### DIFF
--- a/fnl.lua
+++ b/fnl.lua
@@ -826,6 +826,22 @@ SPECIALS['$'] = function(ast, scope, parent)
     return SPECIALS.fn({'', sym('$$'), fargs, ast, n = 4}, scope, parent)
 end
 
+SPECIALS['lambda'] = function(ast, scope, parent)
+    table.remove(ast, 1)
+    local arglist = table.remove(ast, 1)
+    for _,arg in ipairs(arglist) do
+        if not arg[1]:match("^?") then
+            table.insert(ast, 1,
+                         list(sym("when"), list(sym("not"), arg),
+                              list(sym("error"),
+                                   "Missing argument: " .. arg[1])))
+        end
+    end
+    local new = list(sym("lambda"), arglist, unpack(ast))
+    return SPECIALS.fn(new, scope, parent)
+end
+SPECIALS['λ'] = SPECIALS['lambda']
+
 SPECIALS['special'] = function(ast, scope, parent)
     assert(scopeInside(COMPILER_SCOPE, scope), 'can only declare special forms in \'eval-compiler\'')
     local spec = SPECIALS.fn(ast, scope, parent)

--- a/test_core.lua
+++ b/test_core.lua
@@ -32,6 +32,11 @@ local functions = {
          (f 9 5 (f3 f2)))"]=44,
     ["(let [a 11 f (fn [] (set a (+ a 2)))] (f) (f) a)"]=15,
     ["(if (= nil ((fn [a]) 1)) :pass :fail)"]="pass",
+    ["(let [res (pack (pcall error \"oh no\"))] (. res 2))"]="oh no",
+    ["(let [l (lambda [x] (+ x x))] (l 4))"]=8,
+    ["(let [l (λ [x] x) res (pack (pcall l))] (. res 1))"]=false,
+    ["(let [l (λ [x y] x) r (pack (pcall l 1))]\
+        (string.match (. r 2) \"Missing argument: y\")"]="Missing argument: y",
 }
 
 local conditionals = {


### PR DESCRIPTION
This checks for all non-?-beginning parameters to be non-nil. It doesn't check for cases where there are too many parameters, as I don't believe it's possible to know how many params are passed in unless using var-args.